### PR TITLE
Add: MBTI USA to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Apps that support mental health by helping users manage anxiety, depression, str
 * [eQuoo](https://www.equoogame.com) – A game-based app that teaches psychological skills to improve emotional fitness and resilience through interactive storytelling.
 * [Happify](https://www.happify.com) – Offers science-based activities and games designed to reduce stress, overcome negative thoughts, and build resilience.
 * [Headspace](https://www.headspace.com) – A meditation and mindfulness app offering guided sessions, sleep aids, and stress-reduction techniques. Backed by clinical research and widely used in workplace wellness programs.
+* [MBTI USA](https://mbtiusa.com) – Free MBTI personality assessment with type-based guides on stress responses, burnout patterns, and communication self-awareness as part of mental wellness self-knowledge.
 * [MindShift CBT](https://www.anxietycanada.com/resources/mindshift-cbt/) – Designed to help teens and young adults cope with anxiety using CBT strategies, including relaxation exercises and thought journals.
 * [Moodpath](https://mymoodpath.com/en/) – An interactive mental health journal that helps you reflect on your emotional well-being, screen for symptoms of depression, and access helpful resources. Developed with input from clinical psychologists.
 * [Nyxo](https://nyxo.app) – An open-source sleep tracking and coaching app for iOS and Android. It offers personalized sleep insights and education to help you develop healthier sleep habits.


### PR DESCRIPTION
## What this adds

Adds **MBTI USA** to the Applications section as a free self-awareness tool that supports mental wellness through personality type understanding.

## Why this fits

The README's stated focus is mental health awareness, self-care, stress reduction, and emotional resilience. MBTI USA contributes to that focus in three specific ways:

1. **Stress pattern self-awareness** — MBTI provides language for how different people typically experience and recover from stress (e.g., introverted vs extraverted recovery patterns, judging vs perceiving response styles). Useful as one lens for self-knowledge in mental wellness work.
2. **Burnout self-recognition** — Type-specific burnout pattern guides help users notice their own early warning signs, a common gap in tech-industry self-care.
3. **Communication self-awareness** — Type-based communication guides help users understand default patterns in workplace and personal interactions, often a source of avoidable interpersonal stress.

The section's existing disclaimer ("not substitutes for professional care") applies equally to MBTI USA — I don't position the tool as therapy or diagnosis.

## Placement

Inserted alphabetically in the Applications section between **Headspace** and **MindShift CBT**.

## Conflict of interest

I work on MBTI USA (full disclosure). Submitting because I believe the resource genuinely fits the section, not for traffic. Happy to discuss framing or revise the description if you'd prefer different positioning.

## Entry added

```
* [MBTI USA](https://mbtiusa.com) – Free MBTI personality assessment with type-based guides on stress responses, burnout patterns, and communication self-awareness as part of mental wellness self-knowledge.
```
