### PR TITLE
Add Basal to Apps - Therapeutic Journaling App With Evidence-Based Frameworks

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,6 +2,7 @@
 
 Here you have the awesome people who contributed to this list (ordered **alphabetically** by **surname**):
 
+- [Adeel Ahmad](https://github.com/realadeel/).
 - [Andy Alt](https://github.com/andy5995/).
 - [Joe Bell](https://github.com/joe-bell).
 - [Agustín Covarrubias](https://github.com/agucova).

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ It covers topics including, but not limited to:
 
 Apps that support mental health by helping users manage anxiety, depression, stress, sleep, and emotional resilience. These tools are not substitutes for professional care, but they can complement therapy or serve as entry points to self-reflection and support.
 
+* [Basal](https://thinkbasal.com) – Therapeutic journaling app that reflects each entry through ten evidence-based frameworks including CBT, IFS, ACT, DBT, and Stoicism, alongside 37 validated assessments. No account required; all data stays on-device. iOS, Android, and Apple Watch.
 * [Calm](https://www.calm.com) – Provides guided meditations, sleep stories, and breathing exercises to help reduce anxiety and improve sleep quality.
 * [Cope Notes](https://www.copenotes.com) – Sends daily text messages with positive thoughts, exercises, and journaling prompts to help combat depression and anxiety. Content is reviewed by mental health professionals.
 * [EmoBay](https://emobay.org) – An AI-driven digital mental health platform offering 24/7 conversational support, mood tracking, and crisis-response guidance via a chatbot interface.


### PR DESCRIPTION
Adding Basal (https://thinkbasal.com) to the Apps section, alphabetically before Calm.

Basal is a journaling app that processes each entry through ten evidence-based therapeutic frameworks: CBT, IFS, ACT, DBT, Stoicism, Psychodynamic, Existential, Narrative, Somatic, and Self-Compassion. It also includes 37 validated mental health assessments (PHQ-9, GAD-7, and others).

Per the contribution guidelines, apps are exempt from the clinical evidence requirement. No therapeutic claims are made in the entry — the description reflects what the app does, consistent with how Woebot, Wysa, and other existing entries are described.

Privacy: no account required, all journal history stored on-device, no cloud sync, no ads.

Available on iOS, Android, and Apple Watch. Free with 7-day history; Pro at $6.99/month.

I've also added myself to CONTRIBUTORS.md alphabetically.