### PR TITLE
Add Crisis Mode overload support tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Apps that support mental health by helping users manage anxiety, depression, str
 * [eQuoo](https://www.equoogame.com) – A game-based app that teaches psychological skills to improve emotional fitness and resilience through interactive storytelling.
 * [Happify](https://www.happify.com) – Offers science-based activities and games designed to reduce stress, overcome negative thoughts, and build resilience.
 * [Headspace](https://www.headspace.com) – A meditation and mindfulness app offering guided sessions, sleep aids, and stress-reduction techniques. Backed by clinical research and widely used in workplace wellness programs.
+* [Masked But Aware Crisis Mode](https://www.maskedbutaware.nl/en/tools/crisis-mode) – A browser-based tool for reducing decisions during overload and communicating immediate support needs. It is a self-help aid, not an emergency service.
 * [MindShift CBT](https://www.anxietycanada.com/resources/mindshift-cbt/) – Designed to help teens and young adults cope with anxiety using CBT strategies, including relaxation exercises and thought journals.
 * [Moodpath](https://mymoodpath.com/en/) – An interactive mental health journal that helps you reflect on your emotional well-being, screen for symptoms of depression, and access helpful resources. Developed with input from clinical psychologists.
 * [Nyxo](https://nyxo.app) – An open-source sleep tracking and coaching app for iOS and Android. It offers personalized sleep insights and education to help you develop healthier sleep habits.


### PR DESCRIPTION
Adds Crisis Mode to Applications. It is a browser-based aid that reduces decisions during overload and lets someone communicate immediate support needs. The description explicitly distinguishes it from emergency support.\n\nDisclosure: I maintain Masked But Aware, the submitted resource.\n\nChecked: the direct URL returns HTTP 200 and the Markdown diff passes .